### PR TITLE
This apparently fixes it?

### DIFF
--- a/include/buggy/buggy.hpp
+++ b/include/buggy/buggy.hpp
@@ -9,7 +9,7 @@ using namespace std;
 namespace buggy {
 
 struct buggy_struct {
-  eosiosystem::eosio_global_state global;
+  optional<eosiosystem::eosio_global_state> global;
   eosiosystem::powerup_state powerup;
   eosiosystem::exchange_state ram;
   eosiosystem::rex_pool rex;


### PR DESCRIPTION
Example PR related to https://github.com/AntelopeIO/cdt/issues/339

Making this property optional for whatever reason prevents the memory leak